### PR TITLE
Fix JSON pretty print and Ctrl+C/V/A issues

### DIFF
--- a/webview/package-lock.json
+++ b/webview/package-lock.json
@@ -4384,9 +4384,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.2.tgz",
-      "integrity": "sha512-8Ao+EDmTPjZ1ZBABc1ohN7Ylx7UIYcjReZinigedTOnGFhIctyGPxY2II+hJ6gD2/vkDKZTyQ0e7++kwv6wDrw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
+      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
       "cpu": [
         "arm"
       ],
@@ -4398,9 +4398,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.2.tgz",
-      "integrity": "sha512-I+B1v0a4iqdS9DvYt1RJZ3W+Oh9EVWjbY6gp79aAYipIbxSLEoQtFQlZEnUuwhDXCqMxJ3hluxKAdPD+GiluFQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
+      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
       "cpu": [
         "arm64"
       ],
@@ -4412,9 +4412,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.2.tgz",
-      "integrity": "sha512-BTHO7rR+LC67OP7I8N8GvdvnQqzFujJYWo7qCQ8fGdQcb8Gn6EQY+K1P+daQLnDCuWKbZ+gHAQZuKiQkXkqIYg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
+      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
       "cpu": [
         "arm64"
       ],
@@ -4426,9 +4426,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.2.tgz",
-      "integrity": "sha512-1esGwDNFe2lov4I6GsEeYaAMHwkqk0IbuGH7gXGdBmd/EP9QddJJvTtTF/jv+7R8ZTYPqwcdLpMTxK8ytP6k6Q==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
+      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
       "cpu": [
         "x64"
       ],
@@ -4440,9 +4440,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.2.tgz",
-      "integrity": "sha512-GBHuY07x96OTEM3OQLNaUSUwrOhdMea/LDmlFHi/HMonrgF6jcFrrFFwJhhe84XtA1oK/Qh4yFS+VMREf6dobg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
+      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
       "cpu": [
         "arm"
       ],
@@ -4454,9 +4454,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.2.tgz",
-      "integrity": "sha512-Dbfa9Sc1G1lWxop0gNguXOfGhaXQWAGhZUcqA0Vs6CnJq8JW/YOw/KvyGtQFmz4yDr0H4v9X248SM7bizYj4yQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
+      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
       "cpu": [
         "arm"
       ],
@@ -4468,9 +4468,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.2.tgz",
-      "integrity": "sha512-Z1YpgBvFYhZIyBW5BoopwSg+t7yqEhs5HCei4JbsaXnhz/eZehT18DaXl957aaE9QK7TRGFryCAtStZywcQe1A==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
+      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
       "cpu": [
         "arm64"
       ],
@@ -4482,9 +4482,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.2.tgz",
-      "integrity": "sha512-66Zszr7i/JaQ0u/lefcfaAw16wh3oT72vSqubIMQqWzOg85bGCPhoeykG/cC5uvMzH80DQa2L539IqKht6twVA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
+      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
       "cpu": [
         "arm64"
       ],
@@ -4496,9 +4496,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.2.tgz",
-      "integrity": "sha512-HpJCMnlMTfEhwo19bajvdraQMcAq3FX08QDx3OfQgb+414xZhKNf3jNvLFYKbbDSGBBrQh5yNwWZrdK0g0pokg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
+      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
       "cpu": [
         "ppc64"
       ],
@@ -4510,9 +4510,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.2.tgz",
-      "integrity": "sha512-/egzQzbOSRef2vYCINKITGrlwkzP7uXRnL+xU2j75kDVp3iPdcF0TIlfwTRF8woBZllhk3QaxNOEj2Ogh3t9hg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
+      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
       "cpu": [
         "riscv64"
       ],
@@ -4524,9 +4524,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.2.tgz",
-      "integrity": "sha512-qgYbOEbrPfEkH/OnUJd1/q4s89FvNJQIUldx8X2F/UM5sEbtkqZpf2s0yly2jSCKr1zUUOY1hnTP2J1WOzMAdA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
+      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
       "cpu": [
         "s390x"
       ],
@@ -4538,9 +4538,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.2.tgz",
-      "integrity": "sha512-a0lkvNhFLhf+w7A95XeBqGQaG0KfS3hPFJnz1uraSdUe/XImkp/Psq0Ca0/UdD5IEAGoENVmnYrzSC9Y2a2uKQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
       "cpu": [
         "x64"
       ],
@@ -4552,9 +4552,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.2.tgz",
-      "integrity": "sha512-sSWBVZgzwtsuG9Dxi9kjYOUu/wKW+jrbzj4Cclabqnfkot8Z3VEHcIgyenA3lLn/Fu11uDviWjhctulkhEO60g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
+      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
       "cpu": [
         "x64"
       ],
@@ -4566,9 +4566,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.2.tgz",
-      "integrity": "sha512-t/YgCbZ638R/r7IKb9yCM6nAek1RUvyNdfU0SHMDLOf6GFe/VG1wdiUAsxTWHKqjyzkRGg897ZfCpdo1bsCSsA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
+      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
       "cpu": [
         "arm64"
       ],
@@ -4580,9 +4580,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.2.tgz",
-      "integrity": "sha512-kTmX5uGs3WYOA+gYDgI6ITkZng9SP71FEMoHNkn+cnmb9Zuyyay8pf0oO5twtTwSjNGy1jlaWooTIr+Dw4tIbw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
+      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
       "cpu": [
         "ia32"
       ],
@@ -4594,9 +4594,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.2.tgz",
-      "integrity": "sha512-Yy8So+SoRz8I3NS4Bjh91BICPOSVgdompTIPYTByUqU66AXSIOgmW3Lv1ke3NORPqxdF+RdrZET+8vYai6f4aA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
+      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
       "cpu": [
         "x64"
       ],
@@ -4662,9 +4662,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7155,13 +7155,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.2.tgz",
-      "integrity": "sha512-JWWpTrZmqQGQWt16xvNn6KVIUz16VtZwl984TKw0dfqqRpFwtLJYYk1/4BTgplndMQKWUk/yB4uOShYmMzA2Vg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -7171,22 +7171,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.22.2",
-        "@rollup/rollup-android-arm64": "4.22.2",
-        "@rollup/rollup-darwin-arm64": "4.22.2",
-        "@rollup/rollup-darwin-x64": "4.22.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.22.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.22.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.22.2",
-        "@rollup/rollup-linux-arm64-musl": "4.22.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.22.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.22.2",
-        "@rollup/rollup-linux-x64-gnu": "4.22.2",
-        "@rollup/rollup-linux-x64-musl": "4.22.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.22.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.22.2",
-        "@rollup/rollup-win32-x64-msvc": "4.22.2",
+        "@rollup/rollup-android-arm-eabi": "4.24.0",
+        "@rollup/rollup-android-arm64": "4.24.0",
+        "@rollup/rollup-darwin-arm64": "4.24.0",
+        "@rollup/rollup-darwin-x64": "4.24.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
+        "@rollup/rollup-linux-arm64-musl": "4.24.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-musl": "4.24.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
+        "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/webview/src/ConfigView/ConfigModal.tsx
+++ b/webview/src/ConfigView/ConfigModal.tsx
@@ -1,14 +1,13 @@
-import {
-  Modal,
-  ModalContent,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  Button,
-  Input,
-} from "@nextui-org/react";
+import { Button, Input } from "@nextui-org/react";
 import { Eye, EyeOff } from "lucide-react";
 
+import {
+  ModalBody,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "../Shared/components/Modal";
 import { BrokerConfig } from "../Shared/interfaces";
 import { useEffect, useState } from "react";
 

--- a/webview/src/PublishView/PublishView.tsx
+++ b/webview/src/PublishView/PublishView.tsx
@@ -5,12 +5,11 @@ import {
   Input,
   Textarea,
   Button,
-  Accordion,
-  AccordionItem,
   Switch,
   Slider,
 } from "@nextui-org/react";
 
+import { Accordion, AccordionItem } from "../Shared/components/Accordion";
 import ConnectionManager from "../Shared/components/ConnectionManager";
 import SolaceManager from "../Shared/SolaceManager";
 import {

--- a/webview/src/PublishView/UserProperties.tsx
+++ b/webview/src/PublishView/UserProperties.tsx
@@ -13,17 +13,19 @@ import {
   TableRow,
   TableCell,
   Tooltip,
-  Modal,
-  ModalContent,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
   Select,
   SelectItem,
 } from "@nextui-org/react";
 import { Pencil, Trash2 } from "lucide-react";
 import solace from "solclientjs";
 
+import {
+  ModalBody,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "../Shared/components/Modal";
 import { Accordion, AccordionItem } from "../Shared/components/Accordion";
 import { UserPropertiesMap } from "../Shared/interfaces";
 import { convertTypeToString } from "../Shared/utils";

--- a/webview/src/PublishView/UserProperties.tsx
+++ b/webview/src/PublishView/UserProperties.tsx
@@ -6,8 +6,6 @@ import {
   Input,
   Textarea,
   Button,
-  Accordion,
-  AccordionItem,
   Table,
   TableHeader,
   TableColumn,
@@ -26,6 +24,7 @@ import {
 import { Pencil, Trash2 } from "lucide-react";
 import solace from "solclientjs";
 
+import { Accordion, AccordionItem } from "../Shared/components/Accordion";
 import { UserPropertiesMap } from "../Shared/interfaces";
 import { convertTypeToString } from "../Shared/utils";
 

--- a/webview/src/Shared/components/Accordion/Accordion.tsx
+++ b/webview/src/Shared/components/Accordion/Accordion.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable react-hooks/exhaustive-deps */
+import {forwardRef} from "@nextui-org/system";
+import {LayoutGroup} from "framer-motion";
+import {Divider} from "@nextui-org/divider";
+import {Fragment, Key, useCallback, useMemo} from "react";
+
+import {UseAccordionProps, useAccordion} from "./useAccordion"
+import AccordionItem from "./AccordionItem"
+
+export interface AccordionProps extends UseAccordionProps {}
+
+const AccordionGroup = forwardRef<"div", AccordionProps>((props, ref) => {
+  const {
+    Component,
+    values,
+    state,
+    isSplitted,
+    showDivider,
+    getBaseProps,
+    disableAnimation,
+    handleFocusChanged: handleFocusChangedProps,
+    itemClasses,
+    dividerProps,
+  } = useAccordion({
+    ...props,
+    ref,
+  });
+  const handleFocusChanged = useCallback(
+    (isFocused: boolean, key: Key) => handleFocusChangedProps(isFocused, key),
+    [handleFocusChangedProps],
+  );
+
+  const content = useMemo(() => {
+    return [...state.collection].map((item, index) => {
+      const classNames = {...itemClasses, ...(item.props.classNames || {})};
+
+      return (
+        <Fragment key={item.key}>
+          <AccordionItem
+            item={item}
+            variant={props.variant}
+            onFocusChange={handleFocusChanged}
+            {...values}
+            {...item.props}
+            classNames={classNames}
+          />
+          {!item.props.hidden &&
+            !isSplitted &&
+            showDivider &&
+            index < state.collection.size - 1 && <Divider {...dividerProps} />}
+        </Fragment>
+      );
+    });
+  }, [values, itemClasses, handleFocusChanged, isSplitted, showDivider, state.collection]);
+
+  return (
+    <Component {...getBaseProps()}>
+      {disableAnimation ? content : <LayoutGroup>{content}</LayoutGroup>}
+    </Component>
+  );
+});
+
+AccordionGroup.displayName = "NextUI.Accordion";
+
+export default AccordionGroup;

--- a/webview/src/Shared/components/Accordion/AccordionIemBase.tsx
+++ b/webview/src/Shared/components/Accordion/AccordionIemBase.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import type {
+  AccordionItemVariantProps,
+  AccordionItemSlots,
+  SlotsToClasses,
+} from "@nextui-org/theme";
+
+import {As} from "@nextui-org/system";
+import {ItemProps, BaseItem} from "@nextui-org/aria-utils";
+import {FocusableProps, PressEvents} from "@react-types/shared";
+import {ReactNode, MouseEventHandler} from "react";
+import {HTMLMotionProps} from "framer-motion";
+
+export type AccordionItemIndicatorProps = {
+  /**
+   * The current indicator, usually an arrow icon.
+   */
+  indicator?: ReactNode;
+  /**
+   * The current open status.
+   */
+  isOpen?: boolean;
+  /**
+   * The current disabled status.
+   * @default false
+   */
+  isDisabled?: boolean;
+};
+
+export interface Props<T extends object = {}>
+  extends Omit<ItemProps<"button", T>, "children" | "title" | keyof FocusableProps>,
+    FocusableProps,
+    PressEvents {
+  /**
+   * The content of the component.
+   */
+  children?: ReactNode | null;
+  /**
+   * The accordion item title.
+   */
+  title?: ReactNode | string;
+  /**
+   * The accordion item subtitle.
+   */
+  subtitle?: ReactNode | string;
+  /**
+   * The accordion item `expanded` indicator, it's usually an arrow icon.
+   * If you pass a function, NextUI will expose the current indicator and the open status,
+   * In case you want to use a custom indicator or modify the current one.
+   */
+  indicator?: ReactNode | ((props: AccordionItemIndicatorProps) => ReactNode) | null;
+  /**
+   * The accordion item start content, it's usually an icon or avatar.
+   */
+  startContent?: ReactNode;
+  /**
+   * The props to modify the framer motion animation. Use the `variants` API to create your own animation.
+   */
+  motionProps?: HTMLMotionProps<"section">;
+  /**
+   * Whether to keep the accordion content mounted when collapsed.
+   * @default false
+   */
+  keepContentMounted?: boolean;
+  /**
+   * The native button click event handler.
+   * @deprecated - use `onPress` instead.
+   */
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Classname or List of classes to change the classNames of the element.
+   * if `className` is passed, it will be added to the base slot.
+   *
+   * @example
+   * ```ts
+   * <AccordionItem classNames={{
+   *    base:"base-classes",
+   *    heading: "heading-classes",
+   *    trigger: "trigger-classes",
+   *    startContent: "start-indicator-classes",
+   *    indicator: "indicator-classes",
+   *    titleWrapper: "title-wrapper-classes", // this wraps the title and subtitle
+   *    title: "title-classes",
+   *    subtitle: "subtitle-classes",
+   *    content: "content-classes",
+   * }} />
+   * ```
+   */
+  classNames?: SlotsToClasses<AccordionItemSlots>;
+  /**
+   * Customizable heading tag for Web accessibility:
+   * use headings to describe content and use them consistently and semantically.
+   * This will help all users to better find the content they are looking for.
+   */
+  HeadingComponent?: As;
+}
+
+export type AccordionItemBaseProps<T extends object = {}> = Props<T> & AccordionItemVariantProps;
+
+const AccordionItemBase = BaseItem as (props: AccordionItemBaseProps) => JSX.Element;
+
+export default AccordionItemBase;

--- a/webview/src/Shared/components/Accordion/AccordionItem.tsx
+++ b/webview/src/Shared/components/Accordion/AccordionItem.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable react-hooks/exhaustive-deps */
+import type {Variants} from "framer-motion";
+
+import {forwardRef} from "@nextui-org/system";
+import {useMemo, ReactNode} from "react";
+import {ChevronIcon} from "@nextui-org/shared-icons";
+import {AnimatePresence, LazyMotion, domAnimation, m, useWillChange} from "framer-motion";
+import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";
+
+import {UseAccordionItemProps, useAccordionItem} from "./useAccordionItem";
+
+
+export interface AccordionItemProps extends UseAccordionItemProps {}
+
+const AccordionItem = forwardRef<"button", AccordionItemProps>((props, ref) => {
+  const {
+    Component,
+    HeadingComponent,
+    classNames,
+    slots,
+    indicator,
+    children,
+    title,
+    subtitle,
+    startContent,
+    isOpen,
+    isDisabled,
+    hideIndicator,
+    keepContentMounted,
+    disableAnimation,
+    motionProps,
+    getBaseProps,
+    getHeadingProps,
+    getButtonProps,
+    getTitleProps,
+    getSubtitleProps,
+    getContentProps,
+    getIndicatorProps,
+  } = useAccordionItem({...props, ref});
+
+  const willChange = useWillChange();
+
+  const indicatorContent = useMemo<ReactNode | null>(() => {
+    if (typeof indicator === "function") {
+      return indicator({indicator: <ChevronIcon />, isOpen, isDisabled});
+    }
+
+    if (indicator) return indicator;
+
+    return null;
+  }, [indicator, isOpen, isDisabled]);
+
+  const indicatorComponent = indicatorContent || <ChevronIcon />;
+
+  const content = useMemo(() => {
+    if (disableAnimation) {
+      return <div {...getContentProps()}>{children}</div>;
+    }
+
+    const transitionVariants: Variants = {
+      exit: {...TRANSITION_VARIANTS.collapse.exit, overflowY: "hidden"},
+      enter: {...TRANSITION_VARIANTS.collapse.enter, overflowY: "unset"},
+    };
+
+    return keepContentMounted ? (
+      <LazyMotion features={domAnimation}>
+        <m.section
+          key="accordion-content"
+          animate={isOpen ? "enter" : "exit"}
+          exit="exit"
+          initial="exit"
+          style={{willChange}}
+          variants={transitionVariants}
+          {...motionProps}
+        >
+          <div {...getContentProps()}>{children}</div>
+        </m.section>
+      </LazyMotion>
+    ) : (
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <LazyMotion features={domAnimation}>
+            <m.section
+              key="accordion-content"
+              animate="enter"
+              exit="exit"
+              initial="exit"
+              style={{willChange}}
+              variants={transitionVariants}
+              {...motionProps}
+            >
+              <div {...getContentProps()}>{children}</div>
+            </m.section>
+          </LazyMotion>
+        )}
+      </AnimatePresence>
+    );
+  }, [isOpen, disableAnimation, keepContentMounted, children, motionProps]);
+
+  return (
+    <Component {...getBaseProps()}>
+      <HeadingComponent {...getHeadingProps()}>
+        <button {...getButtonProps()}>
+          {startContent && (
+            <div className={slots.startContent({class: classNames?.startContent})}>
+              {startContent}
+            </div>
+          )}
+          <div className={slots.titleWrapper({class: classNames?.titleWrapper})}>
+            {title && <span {...getTitleProps()}>{title}</span>}
+            {subtitle && <span {...getSubtitleProps()}>{subtitle}</span>}
+          </div>
+          {!hideIndicator && indicatorComponent && (
+            <span {...getIndicatorProps()}>{indicatorComponent}</span>
+          )}
+        </button>
+      </HeadingComponent>
+      {content}
+    </Component>
+  );
+});
+
+AccordionItem.displayName = "NextUI.AccordionItem";
+
+export default AccordionItem;

--- a/webview/src/Shared/components/Accordion/README.md
+++ b/webview/src/Shared/components/Accordion/README.md
@@ -1,0 +1,3 @@
+# Disclaimer
+
+Source code within this directory has been copied over from https://github.com/nextui-org/nextui/blob/canary/packages/components/accordion to fix the issue of prevent all key down events.

--- a/webview/src/Shared/components/Accordion/index.tsx
+++ b/webview/src/Shared/components/Accordion/index.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable react-refresh/only-export-components */
+import AccordionItem from "./AccordionIemBase";
+import Accordion from "./Accordion";
+
+// export types
+export type { AccordionProps } from "./Accordion";
+export type { AccordionItemIndicatorProps } from "./AccordionIemBase";
+export type { AccordionItemBaseProps as AccordionItemProps } from "./AccordionIemBase";
+
+// export hooks
+export { useAccordionItem } from "./useAccordionItem";
+export { useAccordion } from "./useAccordion";
+
+// export component
+export { Accordion, AccordionItem };

--- a/webview/src/Shared/components/Accordion/useAccordion.tsx
+++ b/webview/src/Shared/components/Accordion/useAccordion.tsx
@@ -1,0 +1,255 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable react-hooks/exhaustive-deps */
+import type { SelectionBehavior, MultipleSelection } from "@react-types/shared";
+import type { AriaAccordionProps } from "@react-types/accordion";
+import type { AccordionGroupVariantProps } from "@nextui-org/theme";
+import type { HTMLNextUIProps, PropGetter } from "@nextui-org/system";
+
+import { useProviderContext } from "@nextui-org/system";
+import { ReactRef, filterDOMProps } from "@nextui-org/react-utils";
+import React, { Key, useCallback } from "react";
+import { TreeState, useTreeState } from "@react-stately/tree";
+import { mergeProps } from "@react-aria/utils";
+import { accordion } from "@nextui-org/theme";
+import { useDOMRef } from "@nextui-org/react-utils";
+import { useMemo, useState } from "react";
+import { DividerProps } from "@nextui-org/divider";
+import { useReactAriaAccordion } from "@nextui-org/use-aria-accordion";
+
+import { AccordionItemProps } from "./AccordionItem";
+
+interface Props extends HTMLNextUIProps<"div"> {
+  /**
+   * Ref to the DOM node.
+   */
+  ref?: ReactRef<HTMLDivElement | null>;
+  /**
+   * Whether to display a divider at the bottom of the each accordion item.
+   *
+   * @default true
+   */
+  showDivider?: boolean;
+  /**
+   * The divider props.
+   */
+  dividerProps?: Partial<DividerProps>;
+  /**
+   * The accordion selection behavior.
+   * @default "toggle"
+   */
+  selectionBehavior?: SelectionBehavior;
+  /**
+   * Whether to keep the accordion content mounted when collapsed.
+   * @default false
+   */
+  keepContentMounted?: boolean;
+  /**
+   * The accordion items classNames.
+   */
+  itemClasses?: AccordionItemProps["classNames"];
+}
+
+export type UseAccordionProps<T extends object = {}> = Props &
+  AccordionGroupVariantProps &
+  Pick<
+    AccordionItemProps,
+    | "isCompact"
+    | "isDisabled"
+    | "hideIndicator"
+    | "disableAnimation"
+    | "disableIndicatorAnimation"
+    | "motionProps"
+  > &
+  AriaAccordionProps<T> &
+  MultipleSelection;
+
+export type ValuesType<T extends object = {}> = {
+  state: TreeState<T>;
+  focusedKey?: Key | null;
+  isCompact?: AccordionItemProps["isCompact"];
+  isDisabled?: AccordionItemProps["isDisabled"];
+  hideIndicator?: AccordionItemProps["hideIndicator"];
+  disableAnimation?: AccordionItemProps["disableAnimation"];
+  keepContentMounted?: Props["keepContentMounted"];
+  disableIndicatorAnimation?: AccordionItemProps["disableAnimation"];
+  motionProps?: AccordionItemProps["motionProps"];
+};
+
+export function useAccordion<T extends object>(props: UseAccordionProps<T>) {
+  const globalContext = useProviderContext();
+
+  const {
+    ref,
+    as,
+    className,
+    items,
+    variant,
+    motionProps,
+    expandedKeys,
+    disabledKeys,
+    selectedKeys,
+    children: childrenProp,
+    defaultExpandedKeys,
+    selectionMode = "single",
+    selectionBehavior = "toggle",
+    keepContentMounted = false,
+    disallowEmptySelection,
+    defaultSelectedKeys,
+    onExpandedChange,
+    onSelectionChange,
+    dividerProps = {},
+    isCompact = false,
+    isDisabled = false,
+    showDivider = true,
+    hideIndicator = false,
+    disableAnimation = globalContext?.disableAnimation ?? false,
+    disableIndicatorAnimation = false,
+    itemClasses,
+    ...otherProps
+  } = props;
+
+  const [focusedKey, setFocusedKey] = useState<Key | null>(null);
+
+  const Component = as || "div";
+  const shouldFilterDOMProps = typeof Component === "string";
+
+  const domRef = useDOMRef(ref);
+
+  const classNames = useMemo(
+    () =>
+      accordion({
+        variant,
+        className,
+      }),
+    [variant, className],
+  );
+
+  // TODO: Remove this once the issue is fixed.
+  const children = useMemo(() => {
+    const treeChildren: any = [];
+
+    /**
+     * This is a workaround for rendering ReactNode children in the AccordionItem.
+     * @see https://github.com/adobe/react-spectrum/issues/3882
+     */
+    React.Children.map(childrenProp, (child) => {
+      if (React.isValidElement(child) && typeof child.props?.children !== "string") {
+        const clonedChild = React.cloneElement(child, {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          hasChildItems: false,
+        });
+
+        treeChildren.push(clonedChild);
+      } else {
+        treeChildren.push(child);
+      }
+    });
+
+    return treeChildren;
+  }, [childrenProp]);
+
+  const commonProps = {
+    children,
+    items,
+  };
+
+  const expandableProps = {
+    expandedKeys,
+    defaultExpandedKeys,
+    onExpandedChange,
+  };
+
+  const treeProps = {
+    disabledKeys,
+    selectedKeys,
+    selectionMode,
+    selectionBehavior,
+    disallowEmptySelection,
+    defaultSelectedKeys: defaultSelectedKeys ?? defaultExpandedKeys,
+    onSelectionChange,
+    ...commonProps,
+    ...expandableProps,
+  };
+
+  const state = useTreeState(treeProps);
+
+  state.selectionManager.setFocusedKey = (key: Key | null) => {
+    setFocusedKey(key);
+  };
+
+  const {accordionProps} = useReactAriaAccordion(
+    {
+      ...commonProps,
+      ...expandableProps,
+    },
+    state,
+    domRef,
+  );
+
+  const values: ValuesType<T> = useMemo(
+    () => ({
+      state,
+      focusedKey,
+      motionProps,
+      isCompact,
+      isDisabled,
+      hideIndicator,
+      disableAnimation,
+      keepContentMounted,
+      disableIndicatorAnimation,
+    }),
+    [
+      focusedKey,
+      isCompact,
+      isDisabled,
+      hideIndicator,
+      selectedKeys,
+      disableAnimation,
+      keepContentMounted,
+      state?.expandedKeys.values,
+      disableIndicatorAnimation,
+      state.expandedKeys.size,
+      state.disabledKeys.size,
+      motionProps,
+    ],
+  );
+
+  const getBaseProps: PropGetter = useCallback((props = {}) => {
+    return {
+      ref: domRef,
+      className: classNames,
+      "data-orientation": "vertical",
+      ...mergeProps(
+        accordionProps,
+        filterDOMProps(otherProps, {
+          enabled: shouldFilterDOMProps,
+        }),
+        props,
+      ),
+    };
+  }, []);
+
+  const handleFocusChanged = useCallback((isFocused: boolean, key: Key | null) => {
+    isFocused && setFocusedKey(key);
+  }, []);
+
+  return {
+    Component,
+    values,
+    state,
+    focusedKey,
+    getBaseProps,
+    isSplitted: variant === "splitted",
+    classNames,
+    showDivider,
+    dividerProps,
+    disableAnimation,
+    handleFocusChanged,
+    itemClasses,
+  };
+}
+
+export type UseAccordionReturn = ReturnType<typeof useAccordion>;

--- a/webview/src/Shared/components/Accordion/useAccordionItem.tsx
+++ b/webview/src/Shared/components/Accordion/useAccordionItem.tsx
@@ -1,0 +1,277 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable react-hooks/exhaustive-deps */
+import type {AccordionItemVariantProps} from "@nextui-org/theme";
+
+import {HTMLNextUIProps, PropGetter, useProviderContext} from "@nextui-org/system";
+import {useFocusRing} from "@react-aria/focus";
+import {accordionItem} from "@nextui-org/theme";
+import {clsx, callAllHandlers, dataAttr, objectToDeps} from "@nextui-org/shared-utils";
+import {ReactRef, useDOMRef, filterDOMProps} from "@nextui-org/react-utils";
+import {NodeWithProps} from "@nextui-org/aria-utils";
+import {useReactAriaAccordionItem} from "@nextui-org/use-aria-accordion";
+import {useCallback, useMemo} from "react";
+import {chain, mergeProps} from "@react-aria/utils";
+import {useHover, usePress} from "@react-aria/interactions";
+import {TreeState} from "@react-stately/tree";
+
+import {AccordionItemBaseProps} from "./AccordionIemBase"
+
+export interface Props<T extends object> extends HTMLNextUIProps<"div"> {
+  /**
+   * Ref to the DOM node.
+   */
+  ref?: ReactRef<HTMLButtonElement | null>;
+  /**
+   * The item node.
+   */
+  item: NodeWithProps<T, AccordionItemBaseProps<T>>;
+  /**
+   * The accordion tree state.
+   */
+  state: TreeState<T>;
+  /**
+   * Current focused key.
+   */
+  focusedKey: React.Key | null;
+  /**
+   * Callback fired when the focus state changes.
+   */
+  onFocusChange?: (isFocused: boolean, key?: React.Key) => void;
+}
+
+export type UseAccordionItemProps<T extends object = {}> = Props<T> &
+  AccordionItemVariantProps &
+  Omit<AccordionItemBaseProps, "onFocusChange">;
+
+export function useAccordionItem<T extends object = {}>(props: UseAccordionItemProps<T>) {
+  const globalContext = useProviderContext();
+
+  const {ref, as, item, onFocusChange} = props;
+
+  const {
+    state,
+    className,
+    indicator,
+    children,
+    title,
+    subtitle,
+    startContent,
+    motionProps,
+    focusedKey,
+    variant,
+    isCompact = false,
+    classNames: classNamesProp = {},
+    isDisabled: isDisabledProp = false,
+    hideIndicator = false,
+    disableAnimation = globalContext?.disableAnimation ?? false,
+    keepContentMounted = false,
+    disableIndicatorAnimation = false,
+    HeadingComponent = as || "h2",
+    onPress,
+    onPressStart,
+    onPressEnd,
+    onPressChange,
+    onPressUp,
+    onClick,
+    ...otherProps
+  } = props;
+
+  const Component = as || "div";
+  const shouldFilterDOMProps = typeof Component === "string";
+
+  const domRef = useDOMRef<HTMLButtonElement>(ref);
+
+  const isDisabled = state.disabledKeys.has(item.key) || isDisabledProp;
+  const isOpen = state.selectionManager.isSelected(item.key);
+
+  const {buttonProps: buttonCompleteProps, regionProps} = useReactAriaAccordionItem(
+    {item, isDisabled},
+    {...state, focusedKey: focusedKey},
+    domRef,
+  );
+
+  const {onFocus: onFocusButton, onBlur: onBlurButton, ...buttonProps} = buttonCompleteProps;
+
+  const {isFocused, isFocusVisible, focusProps} = useFocusRing({
+    autoFocus: item.props?.autoFocus,
+  });
+
+  const {isHovered, hoverProps} = useHover({isDisabled});
+
+  const {pressProps, isPressed} = usePress({
+    ref: domRef,
+    isDisabled,
+    onPress,
+    onPressStart,
+    onPressEnd,
+    onPressChange,
+    onPressUp,
+  });
+
+  const handleFocus = useCallback(() => {
+    onFocusChange?.(true, item.key);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    onFocusChange?.(false, item.key);
+  }, []);
+
+  const classNames = useMemo(
+    () => ({
+      ...classNamesProp,
+    }),
+    [objectToDeps(classNamesProp)],
+  );
+
+  const slots = useMemo(
+    () =>
+      accordionItem({
+        isCompact,
+        isDisabled,
+        hideIndicator,
+        disableAnimation,
+        disableIndicatorAnimation,
+        variant,
+      }),
+    [isCompact, isDisabled, hideIndicator, disableAnimation, disableIndicatorAnimation, variant],
+  );
+
+  const baseStyles = clsx(classNames?.base, className);
+
+  const getBaseProps = useCallback<PropGetter>(
+    (props = {}) => {
+      return {
+        "data-open": dataAttr(isOpen),
+        "data-disabled": dataAttr(isDisabled),
+        className: slots.base({class: baseStyles}),
+        ...mergeProps(
+          filterDOMProps(otherProps, {
+            enabled: shouldFilterDOMProps,
+          }),
+          props,
+        ),
+      };
+    },
+    [baseStyles, shouldFilterDOMProps, otherProps, slots, item.props, isOpen, isDisabled],
+  );
+
+  const getButtonProps: PropGetter = (props = {}) => {
+    return {
+      ref: domRef,
+      "data-open": dataAttr(isOpen),
+      "data-focus": dataAttr(isFocused),
+      "data-focus-visible": dataAttr(isFocusVisible),
+      "data-disabled": dataAttr(isDisabled),
+      "data-hover": dataAttr(isHovered),
+      "data-pressed": dataAttr(isPressed),
+      className: slots.trigger({class: classNames?.trigger}),
+      onFocus: callAllHandlers(
+        handleFocus,
+        onFocusButton,
+        focusProps.onFocus,
+        otherProps.onFocus,
+        item.props?.onFocus,
+      ),
+      onBlur: callAllHandlers(
+        handleBlur,
+        onBlurButton,
+        focusProps.onBlur,
+        otherProps.onBlur,
+        item.props?.onBlur,
+      ),
+      ...mergeProps(buttonProps, hoverProps, pressProps, props, {
+        onClick: chain(pressProps.onClick, onClick),
+      }),
+    };
+  };
+
+  const getContentProps = useCallback<PropGetter>(
+    (props = {}) => {
+      return {
+        "data-open": dataAttr(isOpen),
+        "data-disabled": dataAttr(isDisabled),
+        className: slots.content({class: classNames?.content}),
+        ...mergeProps(regionProps, props),
+      };
+    },
+    [slots, classNames, regionProps, isOpen, isDisabled, classNames?.content],
+  );
+
+  const getIndicatorProps = useCallback<PropGetter>(
+    (props = {}) => {
+      return {
+        "aria-hidden": dataAttr(true),
+        "data-open": dataAttr(isOpen),
+        "data-disabled": dataAttr(isDisabled),
+        className: slots.indicator({class: classNames?.indicator}),
+        ...props,
+      };
+    },
+    [slots, classNames?.indicator, isOpen, isDisabled, classNames?.indicator],
+  );
+
+  const getHeadingProps = useCallback<PropGetter>(
+    (props = {}) => {
+      return {
+        "data-open": dataAttr(isOpen),
+        "data-disabled": dataAttr(isDisabled),
+        className: slots.heading({class: classNames?.heading}),
+        ...props,
+      };
+    },
+    [slots, classNames?.heading, isOpen, isDisabled, classNames?.heading],
+  );
+
+  const getTitleProps = useCallback<PropGetter>(
+    (props = {}) => {
+      return {
+        "data-open": dataAttr(isOpen),
+        "data-disabled": dataAttr(isDisabled),
+        className: slots.title({class: classNames?.title}),
+        ...props,
+      };
+    },
+    [slots, classNames?.title, isOpen, isDisabled, classNames?.title],
+  );
+
+  const getSubtitleProps = useCallback<PropGetter>(
+    (props = {}) => {
+      return {
+        "data-open": dataAttr(isOpen),
+        "data-disabled": dataAttr(isDisabled),
+        className: slots.subtitle({class: classNames?.subtitle}),
+        ...props,
+      };
+    },
+    [slots, classNames, isOpen, isDisabled, classNames?.subtitle],
+  );
+
+  return {
+    Component,
+    HeadingComponent,
+    item,
+    slots,
+    classNames,
+    domRef,
+    indicator,
+    children,
+    title,
+    subtitle,
+    startContent,
+    isOpen,
+    isDisabled,
+    hideIndicator,
+    keepContentMounted,
+    disableAnimation,
+    motionProps,
+    getBaseProps,
+    getHeadingProps,
+    getButtonProps,
+    getContentProps,
+    getIndicatorProps,
+    getTitleProps,
+    getSubtitleProps,
+  };
+}
+
+export type UseAccordionItemReturn = ReturnType<typeof useAccordionItem>;

--- a/webview/src/Shared/components/ConfigStore.tsx
+++ b/webview/src/Shared/components/ConfigStore.tsx
@@ -1,17 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
+import { Button, Tooltip, Select, SelectItem, Input } from "@nextui-org/react";
+import { Save, RefreshCcw, Trash2 } from "lucide-react";
+
 import {
-  Button,
-  Tooltip,
-  Select,
-  SelectItem,
   ModalBody,
-  Input,
   Modal,
   ModalContent,
   ModalFooter,
   ModalHeader,
-} from "@nextui-org/react";
-import { Save, RefreshCcw, Trash2 } from "lucide-react";
+} from "./Modal";
 
 import { deepCompareObjects, getVscConfig, setVscConfig } from "../utils";
 import { Configs } from "../interfaces";
@@ -27,7 +24,7 @@ const ConfigStore = ({
   currentConfig,
   onLoadConfig,
   storeKey,
-  isDisabled=false,
+  isDisabled = false,
 }: ConfigStoreProps) => {
   const [lastSavedConfig, setLastSavedConfig] = useState<Configs>();
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);

--- a/webview/src/Shared/components/Modal/README.md
+++ b/webview/src/Shared/components/Modal/README.md
@@ -1,0 +1,3 @@
+# Disclaimer
+
+Source code within this directory has been copied over from https://github.com/nextui-org/nextui/tree/canary/packages/components/modal to fix the issue of prevent focus outside of the webview when dialog is open.

--- a/webview/src/Shared/components/Modal/index.ts
+++ b/webview/src/Shared/components/Modal/index.ts
@@ -1,0 +1,23 @@
+import Modal from "./modal";
+import ModalContent from "./modal-content";
+import ModalHeader from "./modal-header";
+import ModalBody from "./modal-body";
+import ModalFooter from "./modal-footer";
+
+// export types
+export type {ModalProps} from "./modal";
+export type {ModalContentProps} from "./modal-content";
+export type {ModalHeaderProps} from "./modal-header";
+export type {ModalBodyProps} from "./modal-body";
+export type {ModalFooterProps} from "./modal-footer";
+export type {UseDisclosureProps} from "@nextui-org/use-disclosure";
+
+// export hooks
+export {useModal} from "./use-modal";
+export {useDisclosure} from "@nextui-org/use-disclosure";
+
+// export context
+export {ModalProvider, useModalContext} from "./modal-context";
+
+// export components
+export {Modal, ModalContent, ModalHeader, ModalBody, ModalFooter};

--- a/webview/src/Shared/components/Modal/modal-body.tsx
+++ b/webview/src/Shared/components/Modal/modal-body.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import {useEffect} from "react";
+import {forwardRef, HTMLNextUIProps} from "@nextui-org/system";
+import {useDOMRef} from "@nextui-org/react-utils";
+import {clsx} from "@nextui-org/shared-utils";
+
+import {useModalContext} from "./modal-context";
+
+export interface ModalBodyProps extends HTMLNextUIProps<"div"> {}
+
+const ModalBody = forwardRef<"div", ModalBodyProps>((props, ref) => {
+  const {as, children, className, ...otherProps} = props;
+
+  const {slots, classNames, bodyId, setBodyMounted} = useModalContext();
+
+  const domRef = useDOMRef(ref);
+
+  const Component = as || "div";
+
+  /**
+   * Notify us if this component was rendered or used,
+   * so we can append `aria-labelledby` automatically
+   */
+  useEffect(() => {
+    setBodyMounted(true);
+
+    return () => setBodyMounted(false);
+  }, [setBodyMounted]);
+
+  return (
+    <Component
+      ref={domRef}
+      className={slots.body({class: clsx(classNames?.body, className)})}
+      id={bodyId}
+      {...otherProps}
+    >
+      {children}
+    </Component>
+  );
+});
+
+ModalBody.displayName = "NextUI.ModalBody";
+
+export default ModalBody;

--- a/webview/src/Shared/components/Modal/modal-content.tsx
+++ b/webview/src/Shared/components/Modal/modal-content.tsx
@@ -1,0 +1,136 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type {AriaDialogProps} from "@react-aria/dialog";
+import type {HTMLMotionProps} from "framer-motion";
+
+import {cloneElement, isValidElement, ReactNode, useMemo, useCallback} from "react";
+import {forwardRef} from "@nextui-org/system";
+import {DismissButton} from "@react-aria/overlays";
+import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";
+import {CloseIcon} from "@nextui-org/shared-icons";
+import {domAnimation, LazyMotion, m} from "framer-motion";
+import {chain, useViewportSize} from "@react-aria/utils";
+import {HTMLNextUIProps} from "@nextui-org/system";
+import {KeyboardEvent} from "react";
+
+import {useModalContext} from "./modal-context";
+import {scaleInOut} from "./modal-transition";
+
+type KeysToOmit = "children" | "role";
+
+export interface ModalContentProps extends AriaDialogProps, HTMLNextUIProps<"div", KeysToOmit> {
+  children: ReactNode | ((onClose: () => void) => ReactNode);
+}
+
+const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _) => {
+  const {as, children, ...otherProps} = props;
+
+  const {
+    Component: DialogComponent,
+    slots,
+    classNames,
+    motionProps,
+    backdrop,
+    closeButton,
+    hideCloseButton,
+    disableAnimation,
+    getDialogProps,
+    getBackdropProps,
+    getCloseButtonProps,
+    onClose,
+  } = useModalContext();
+
+  const Component = as || DialogComponent || "div";
+
+  const viewport = useViewportSize();
+  const closeButtonContent = isValidElement(closeButton) ? (
+    cloneElement(closeButton, getCloseButtonProps())
+  ) : (
+    <button {...getCloseButtonProps()}>
+      <CloseIcon />
+    </button>
+  );
+
+  // Handle Tab key during IME composition to prevent input carryover
+  const onKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Tab" && e.nativeEvent.isComposing) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  }, []);
+
+  const contentProps = getDialogProps(otherProps);
+  const content = (
+    <Component {...contentProps} onKeyDown={chain(contentProps.onKeyDown, onKeyDown)}>
+      <DismissButton onDismiss={onClose} />
+      {!hideCloseButton && closeButtonContent}
+      {typeof children === "function" ? children(onClose) : children}
+      <DismissButton onDismiss={onClose} />
+    </Component>
+  );
+
+  const backdropContent = useMemo(() => {
+    if (backdrop === "transparent") {
+      return null;
+    }
+
+    if (disableAnimation) {
+      return <div {...getBackdropProps()} />;
+    }
+
+    return (
+      <LazyMotion features={domAnimation}>
+        <m.div
+          animate="enter"
+          exit="exit"
+          initial="exit"
+          variants={TRANSITION_VARIANTS.fade}
+          {...(getBackdropProps() as HTMLMotionProps<"div">)}
+        />
+      </LazyMotion>
+    );
+  }, [backdrop, disableAnimation, getBackdropProps]);
+
+  // set the height dynamically to avoid keyboard covering the bottom modal
+  const viewportStyle = {
+    "--visual-viewport-height": viewport.height + "px",
+  };
+
+  const contents = disableAnimation ? (
+    <div
+      className={slots.wrapper({class: classNames?.wrapper})}
+      data-slot="wrapper"
+      // @ts-ignore
+      style={viewportStyle}
+    >
+      {content}
+    </div>
+  ) : (
+    <LazyMotion features={domAnimation}>
+      <m.div
+        animate="enter"
+        className={slots.wrapper({class: classNames?.wrapper})}
+        data-slot="wrapper"
+        exit="exit"
+        initial="exit"
+        variants={scaleInOut}
+        {...motionProps}
+        // @ts-ignore
+        style={viewportStyle}
+      >
+        {content}
+      </m.div>
+    </LazyMotion>
+  );
+
+  return (
+    <div tabIndex={-1}>
+      {backdropContent}
+      {contents}
+    </div>
+  );
+});
+
+ModalContent.displayName = "NextUI.ModalContent";
+
+export default ModalContent;

--- a/webview/src/Shared/components/Modal/modal-context.ts
+++ b/webview/src/Shared/components/Modal/modal-context.ts
@@ -1,0 +1,9 @@
+import {createContext} from "@nextui-org/react-utils";
+
+import {UseModalReturn} from "./use-modal";
+
+export const [ModalProvider, useModalContext] = createContext<UseModalReturn>({
+  name: "ModalContext",
+  errorMessage:
+    "useModalContext: `context` is undefined. Seems you forgot to wrap all popover components within `<Modal />`",
+});

--- a/webview/src/Shared/components/Modal/modal-footer.tsx
+++ b/webview/src/Shared/components/Modal/modal-footer.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import {forwardRef, HTMLNextUIProps} from "@nextui-org/system";
+import {useDOMRef} from "@nextui-org/react-utils";
+import {clsx} from "@nextui-org/shared-utils";
+
+import {useModalContext} from "./modal-context";
+
+export interface ModalFooterProps extends HTMLNextUIProps<"footer"> {}
+
+const ModalFooter = forwardRef<"footer", ModalFooterProps>((props, ref) => {
+  const {as, children, className, ...otherProps} = props;
+
+  const {slots, classNames} = useModalContext();
+
+  const domRef = useDOMRef(ref);
+
+  const Component = as || "footer";
+
+  return (
+    <Component
+      ref={domRef}
+      className={slots.footer({class: clsx(classNames?.footer, className)})}
+      {...otherProps}
+    >
+      {children}
+    </Component>
+  );
+});
+
+ModalFooter.displayName = "NextUI.ModalFooter";
+
+export default ModalFooter;

--- a/webview/src/Shared/components/Modal/modal-header.tsx
+++ b/webview/src/Shared/components/Modal/modal-header.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import {useEffect} from "react";
+import {forwardRef, HTMLNextUIProps} from "@nextui-org/system";
+import {useDOMRef} from "@nextui-org/react-utils";
+import {clsx} from "@nextui-org/shared-utils";
+
+import {useModalContext} from "./modal-context";
+
+export interface ModalHeaderProps extends HTMLNextUIProps<"header"> {}
+
+const ModalHeader = forwardRef<"header", ModalHeaderProps>((props, ref) => {
+  const {as, children, className, ...otherProps} = props;
+
+  const {slots, classNames, headerId, setHeaderMounted} = useModalContext();
+
+  const domRef = useDOMRef(ref);
+
+  const Component = as || "header";
+
+  /**
+   * Notify us if this component was rendered or used,
+   * so we can append `aria-labelledby` automatically
+   */
+  useEffect(() => {
+    setHeaderMounted(true);
+
+    return () => setHeaderMounted(false);
+  }, [setHeaderMounted]);
+
+  return (
+    <Component
+      ref={domRef}
+      className={slots.header({class: clsx(classNames?.header, className)})}
+      id={headerId}
+      {...otherProps}
+    >
+      {children}
+    </Component>
+  );
+});
+
+ModalHeader.displayName = "NextUI.ModalHeader";
+
+export default ModalHeader;

--- a/webview/src/Shared/components/Modal/modal-transition.ts
+++ b/webview/src/Shared/components/Modal/modal-transition.ts
@@ -1,0 +1,33 @@
+import {TRANSITION_EASINGS} from "@nextui-org/framer-utils";
+
+export const scaleInOut = {
+  enter: {
+    scale: "var(--scale-enter)",
+    y: "var(--slide-enter)",
+    opacity: 1,
+    transition: {
+      scale: {
+        duration: 0.4,
+        ease: TRANSITION_EASINGS.ease,
+      },
+      opacity: {
+        duration: 0.4,
+        ease: TRANSITION_EASINGS.ease,
+      },
+      y: {
+        type: "spring",
+        bounce: 0,
+        duration: 0.6,
+      },
+    },
+  },
+  exit: {
+    scale: "var(--scale-exit)",
+    y: "var(--slide-exit)",
+    opacity: 0,
+    transition: {
+      duration: 0.3,
+      ease: TRANSITION_EASINGS.ease,
+    },
+  },
+};

--- a/webview/src/Shared/components/Modal/modal.tsx
+++ b/webview/src/Shared/components/Modal/modal.tsx
@@ -1,0 +1,35 @@
+import {ReactNode} from "react";
+import {AnimatePresence} from "framer-motion";
+import {Overlay} from "@react-aria/overlays";
+import {forwardRef} from "@nextui-org/system";
+
+import {UseModalProps, useModal} from "./use-modal";
+import {ModalProvider} from "./modal-context";
+
+export interface ModalProps extends UseModalProps {
+  /**
+   * The content of the modal. Usually the ModalContent
+   */
+  children: ReactNode;
+}
+
+const Modal = forwardRef<"div", ModalProps>((props, ref) => {
+  const {children, ...otherProps} = props;
+  const context = useModal({...otherProps, ref});
+
+  const overlay = <Overlay portalContainer={context.portalContainer}>{children}</Overlay>;
+
+  return (
+    <ModalProvider value={context}>
+      {context.disableAnimation && context.isOpen ? (
+        overlay
+      ) : (
+        <AnimatePresence>{context.isOpen ? overlay : null}</AnimatePresence>
+      )}
+    </ModalProvider>
+  );
+});
+
+Modal.displayName = "NextUI.Modal";
+
+export default Modal;

--- a/webview/src/Shared/components/Modal/use-modal.ts
+++ b/webview/src/Shared/components/Modal/use-modal.ts
@@ -1,0 +1,216 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import type {ModalVariantProps, SlotsToClasses, ModalSlots} from "@nextui-org/theme";
+import type {HTMLMotionProps} from "framer-motion";
+
+import {AriaModalOverlayProps} from "@react-aria/overlays";
+import {useAriaModalOverlay} from "@nextui-org/use-aria-modal-overlay";
+import {useCallback, useId, useRef, useState, useMemo, ReactNode} from "react";
+import {modal} from "@nextui-org/theme";
+import {
+  HTMLNextUIProps,
+  mapPropsVariants,
+  PropGetter,
+  useProviderContext,
+} from "@nextui-org/system";
+import {useAriaButton} from "@nextui-org/use-aria-button";
+import {useFocusRing} from "@react-aria/focus";
+import {clsx, dataAttr, objectToDeps} from "@nextui-org/shared-utils";
+import {ReactRef, useDOMRef} from "@nextui-org/react-utils";
+import {useOverlayTriggerState} from "@react-stately/overlays";
+import {OverlayTriggerProps} from "@react-stately/overlays";
+import {mergeRefs, mergeProps} from "@react-aria/utils";
+
+interface Props extends HTMLNextUIProps<"section"> {
+  /**
+   * Ref to the DOM node.
+   */
+  ref?: ReactRef<HTMLElement | null>;
+  /**
+   * The props to modify the framer motion animation. Use the `variants` API to create your own animation.
+   */
+  motionProps?: HTMLMotionProps<"section">;
+  /**
+   * Determines whether to hide the modal close button.
+   * @default false
+   */
+  hideCloseButton?: boolean;
+  /**
+   * Custom modal close button element.
+   */
+  closeButton?: ReactNode;
+  /**
+   * Whether the animation should be disabled.
+   * @default false
+   */
+  disableAnimation?: boolean;
+  /**
+   * The container element in which the overlay portal will be placed.
+   * @default document.body
+   */
+  portalContainer?: Element;
+  /**
+   * Whether the scroll should be blocked when the modal is open.
+   * @default true
+   */
+  shouldBlockScroll?: boolean;
+  /**
+   *  Callback fired when the modal is closed.
+   */
+  onClose?: () => void;
+  /**
+   * Classname or List of classes to change the classNames of the element.
+   * if `className` is passed, it will be added to the base slot.
+   *
+   * @example
+   * ```ts
+   * <Modal classNames={{
+   *    wrapper: "wrapper-classes", // main modal wrapper
+   *    backdrop: "backdrop-classes",
+   *    base:"base-classes", // modal content wrapper
+   *    header: "header-classes", // modal header
+   *    body: "body-classes", // modal body
+   *    footer: "footer-classes", // modal footer
+   *    closeButton: "close-button-classes", // modal close button
+   * }} />
+   * ```
+   */
+  classNames?: SlotsToClasses<ModalSlots>;
+}
+
+export type UseModalProps = Props & OverlayTriggerProps & AriaModalOverlayProps & ModalVariantProps;
+
+export function useModal(originalProps: UseModalProps) {
+  const globalContext = useProviderContext();
+
+  const [props, variantProps] = mapPropsVariants(originalProps, modal.variantKeys);
+
+  const {
+    ref,
+    as,
+    className,
+    classNames,
+
+    isOpen,
+    defaultOpen,
+    onOpenChange,
+    motionProps,
+    closeButton,
+    isDismissable = true,
+    hideCloseButton = false,
+    shouldBlockScroll = true,
+    portalContainer,
+    isKeyboardDismissDisabled = false,
+    onClose,
+    ...otherProps
+  } = props;
+
+  const Component = as || "section";
+
+  const domRef = useDOMRef(ref);
+  const closeButtonRef = useRef<HTMLElement>(null);
+
+  const [headerMounted, setHeaderMounted] = useState(false);
+  const [bodyMounted, setBodyMounted] = useState(false);
+
+  const disableAnimation =
+    originalProps.disableAnimation ?? globalContext?.disableAnimation ?? false;
+
+  const dialogId = useId();
+  const headerId = useId();
+  const bodyId = useId();
+
+  const state = useOverlayTriggerState({
+    isOpen,
+    defaultOpen,
+    onOpenChange: (isOpen) => {
+      onOpenChange?.(isOpen);
+      if (!isOpen) {
+        onClose?.();
+      }
+    },
+  });
+
+  const {modalProps, underlayProps} = useAriaModalOverlay(
+    {
+      isDismissable,
+      shouldBlockScroll,
+      isKeyboardDismissDisabled,
+    },
+    state,
+    domRef,
+  );
+
+  const {buttonProps: closeButtonProps} = useAriaButton({onPress: state.close}, closeButtonRef);
+  const {isFocusVisible: isCloseButtonFocusVisible, focusProps: closeButtonFocusProps} =
+    useFocusRing();
+
+  const baseStyles = clsx(classNames?.base, className);
+
+  const slots = useMemo(
+    () =>
+      modal({
+        ...variantProps,
+        disableAnimation,
+      }),
+    [objectToDeps(variantProps), disableAnimation],
+  );
+
+  const getDialogProps: PropGetter = (props = {}, ref = null) => ({
+    ref: mergeRefs(ref, domRef),
+    ...mergeProps(modalProps, otherProps, props),
+    className: slots.base({class: clsx(baseStyles, props.className)}),
+    id: dialogId,
+    "data-open": dataAttr(state.isOpen),
+    "data-dismissable": dataAttr(isDismissable),
+    "aria-modal": dataAttr(true),
+    "aria-labelledby": headerMounted ? headerId : undefined,
+    "aria-describedby": bodyMounted ? bodyId : undefined,
+  });
+
+  const getBackdropProps = useCallback<PropGetter>(
+    (props = {}) => ({
+      className: slots.backdrop({class: classNames?.backdrop}),
+      onClick: () => state.close(),
+      ...underlayProps,
+      ...props,
+    }),
+    [slots, classNames, underlayProps],
+  );
+
+  const getCloseButtonProps: PropGetter = () => {
+    return {
+      role: "button",
+      tabIndex: 0,
+      "aria-label": "Close",
+      "data-focus-visible": dataAttr(isCloseButtonFocusVisible),
+      className: slots.closeButton({class: classNames?.closeButton}),
+      ...mergeProps(closeButtonProps, closeButtonFocusProps),
+    };
+  };
+
+  return {
+    Component,
+    slots,
+    domRef,
+    headerId,
+    bodyId,
+    motionProps,
+    classNames,
+    isDismissable,
+    closeButton,
+    hideCloseButton,
+    portalContainer,
+    shouldBlockScroll,
+    backdrop: originalProps.backdrop ?? "opaque",
+    isOpen: state.isOpen,
+    onClose: state.close,
+    disableAnimation,
+    setBodyMounted,
+    setHeaderMounted,
+    getDialogProps,
+    getBackdropProps,
+    getCloseButtonProps,
+  };
+}
+
+export type UseModalReturn = ReturnType<typeof useModal>;

--- a/webview/src/SubscribeView/SolaceMessage.tsx
+++ b/webview/src/SubscribeView/SolaceMessage.tsx
@@ -90,7 +90,24 @@ const SolaceMessage = ({ message }: SolaceMessageProps) => {
         <Tooltip content="Open message in VSC">
           <Button
             size="sm"
-            onClick={() => openFileInNewTab(JSON.stringify(message, null, 2))}
+            onClick={() => {
+              let parsedPayload = message.payload;
+              try {
+                parsedPayload = JSON.parse(message.payload);
+              } catch {
+                // Payload not JSON - Do nothing
+              }
+              openFileInNewTab(
+                JSON.stringify(
+                  {
+                    ...message,
+                    payload: parsedPayload,
+                  },
+                  null,
+                  2
+                )
+              );
+            }}
           >
             <ExternalLink size={16} />
           </Button>

--- a/webview/src/SubscribeView/SubscribeView.tsx
+++ b/webview/src/SubscribeView/SubscribeView.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from "react";
 import solace from "solclientjs";
 import {
-  Accordion,
-  AccordionItem,
   Button,
   Chip,
   Input,
@@ -19,6 +17,7 @@ import {
   SubscribeConfigs,
   SubscribeStats,
 } from "../Shared/interfaces";
+import { Accordion, AccordionItem } from "../Shared/components/Accordion";
 import ConfigStore from "../Shared/components/ConfigStore";
 import ConnectionManager from "../Shared/components/ConnectionManager";
 import SolaceManager from "../Shared/SolaceManager";

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Accordion, AccordionItem } from "@nextui-org/react";
+import { Accordion, AccordionItem } from "./Shared/components/Accordion";
 
 import ConfigView from "./ConfigView/ConfigView";
 import PublishView from "./PublishView/PublishView";


### PR DESCRIPTION
Fixes #4 and #2

This pull request includes the following changes:

- Added Pretty JSON support to pretty print JSON payload in a new tab

- Fixed the issue where Ctrl+C/V/A doesn't work by enabling right-click + operation

The changes also include the following file modifications:

- Added a disclaimer to fix the issue of preventing all key down events

- Added a disclaimer to fix the issue of preventing focus outside of the webview when the dialog is open

- Modified the import statements in multiple files to fix import errors

- Added new components and hooks related to the modal functionality

- Modified the SolaceMessage component to handle JSON payload pretty printing in a new tab

- Modified the ConfigStore component to fix unsaved changes detection

- Added new styles for modal animations

Please review and merge these changes.