### PR TITLE
Ignore case filtering + case sensitive meta/userProp printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "solace-try-me-vsc-extension" extension will be documented in this file.
 
+## [0.0.11] - 2024-10-29
+- Ignore case filtering + case sensitive meta/userProp printing
+
 ## [0.0.9] - 2024-10-22
 - Fixed pasting issue for the subscribe view.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "solace-try-me-vsc-extension" extension will be documented in this file.
 
-## [0.0.11] - 2024-10-29
+## [0.0.10] - 2024-10-29
 - Ignore case filtering + case sensitive meta/userProp printing
 
 ## [0.0.9] - 2024-10-22

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solace-try-me-vsc-extension",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solace-try-me-vsc-extension",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "Apache-2.0 license",
       "devDependencies": {
         "@types/mocha": "^10.0.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "solace-try-me-vsc-extension",
   "displayName": "Solace Try Me VSC Extension",
   "description": "VSC built-in tool to visualize and observe events flowing through Solace PubSub+ Broker.",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "publisher": "solace-tools",
   "author": {
     "name": "Cyrus Mobini"

--- a/webview/src/SubscribeView/MessagesView.tsx
+++ b/webview/src/SubscribeView/MessagesView.tsx
@@ -15,22 +15,22 @@ const filterMessages = (messages: Message[], filter: string) => {
   return messages
     .map((message) => {
       // stringify stage
-      let searchable = message.topic + SEARCH_DELIMITER;
-      searchable += message.payload + SEARCH_DELIMITER;
+      let searchable = message.topic.toLowerCase()+ SEARCH_DELIMITER;
+      searchable += message.payload.toLowerCase() + SEARCH_DELIMITER;
       if (message.userProperties) {
         for (const [key, value] of Object.entries(message.userProperties)) {
-          searchable += key + SEARCH_DELIMITER + value + SEARCH_DELIMITER;
+          searchable += key.toLowerCase() + SEARCH_DELIMITER + String(value).toLowerCase() + SEARCH_DELIMITER;
         }
       }
       return [message, searchable] as [Message, string];
     })
-    .filter(([_, searchable]) => {
+    .filter((searchable) => {
       // Filter stage
-      return searchable.includes(filter);
+      return searchable[1].includes(filter);
     })
-    .map(([message, _]) => {
+    .map((message) => {
       // Restore stage
-      return message;
+      return message[0];
     });
 };
 
@@ -63,7 +63,7 @@ const MessagesView = ({
         setSearch(bounceSearch);
       }
     }, BOUNCE_DELAY);
-  }, [bounceSearch]);
+  }, [bounceSearch, search]);
 
   if (messages.length === 0) {
     return (

--- a/webview/src/SubscribeView/MessagesView.tsx
+++ b/webview/src/SubscribeView/MessagesView.tsx
@@ -15,13 +15,14 @@ const filterMessages = (messages: Message[], filter: string) => {
   return messages
     .map((message) => {
       // stringify stage
-      let searchable = message.topic.toLowerCase()+ SEARCH_DELIMITER;
-      searchable += message.payload.toLowerCase() + SEARCH_DELIMITER;
+      let searchable = message.topic + SEARCH_DELIMITER;
+      searchable += message.payload + SEARCH_DELIMITER;
       if (message.userProperties) {
         for (const [key, value] of Object.entries(message.userProperties)) {
-          searchable += key.toLowerCase() + SEARCH_DELIMITER + String(value).toLowerCase() + SEARCH_DELIMITER;
+          searchable += key + SEARCH_DELIMITER + value + SEARCH_DELIMITER;
         }
       }
+      searchable = searchable.toLowerCase();
       return [message, searchable] as [Message, string];
     })
     .filter((searchable) => {
@@ -79,26 +80,31 @@ const MessagesView = ({
           value={bounceSearch}
           onChange={(e) => setBounceSearch(e.target.value)}
         />
-        <Button onClick={() => {
+        <Button
+          onClick={() => {
             setSearch("");
             setBounceSearch("");
-        }} isIconOnly>
+          }}
+          isIconOnly
+        >
           <Eraser />
         </Button>
       </div>
       <Divider className="my-2" />
-      {filteredMessages.length > 0 && <ScrollShadow className="h-[500px] w-full">
-        {filteredMessages.map((message) => (
-          <SolaceMessage
-            key={message._extension_uid}
-            message={message}
-            maxPayloadLength={maxPayloadLength}
-            maxPropertyLength={maxPropertyLength}
-            baseFilePath={baseFilePath}
-            highlight={search}
-          />
-        ))}
-      </ScrollShadow>}
+      {filteredMessages.length > 0 && (
+        <ScrollShadow className="h-[500px] w-full">
+          {filteredMessages.map((message) => (
+            <SolaceMessage
+              key={message._extension_uid}
+              message={message}
+              maxPayloadLength={maxPayloadLength}
+              maxPropertyLength={maxPropertyLength}
+              baseFilePath={baseFilePath}
+              highlight={search}
+            />
+          ))}
+        </ScrollShadow>
+      )}
       {filteredMessages.length === 0 && (
         <p className="text-gray-500 text-center">No messages found.</p>
       )}

--- a/webview/src/SubscribeView/SolaceMessage.tsx
+++ b/webview/src/SubscribeView/SolaceMessage.tsx
@@ -164,7 +164,7 @@ const SolaceMessage = ({
         <div className="flex gap-1 flex-col text-sm">
           {metadata.map(([key, value]) => (
             <div key={key} className="flex gap-2">
-              <p className="text-sm capitalize">{key}</p>
+              <p className="text-sm">{key}</p>
               <p className="text-sm text-default-500">
                 {getContent(value, maxPropertyLength, null)}
               </p>
@@ -179,7 +179,7 @@ const SolaceMessage = ({
             <p className="text-md pb-2">User Properties:</p>
             {userProperties.map(([key, value]) => (
               <div key={key} className="flex gap-2 flex-wrap">
-                <p className="text-sm capitalize">
+                <p className="text-sm">
                   {getHighlightedContent(key, highlight)} (
                   {convertTypeToString((value as { type: number }).type)}
                   ):


### PR DESCRIPTION
## What is the purpose of this change?

Enhance the functionality by implementing case-insensitive filtering for messages, improving the search experience, while maintaining case sensitivity when displaying metadata and user properties to preserve original data presentation.

## How is this accomplished?

The changes involve converting message content and properties to lowercase during the filtering process, ensuring the search is case-insensitive. Additionally, modifications are made to prevent altering the case of metadata and user properties in the user interface.

## Anything reviews should focus on/be aware of?

Reviewers should ensure that the case-insensitive filtering works across various message formats and verify that the displayed metadata and user properties retain their original case as expected.

closes #22